### PR TITLE
The evidence-rail shell

### DIFF
--- a/apps/docs/src/routes/__root.tsx
+++ b/apps/docs/src/routes/__root.tsx
@@ -18,9 +18,9 @@ export const Route = createRootRoute({
     meta: [
       { charSet: "utf-8" },
       { name: "viewport", content: "width=device-width, initial-scale=1" },
-      // The browser chrome takes the page's own ground. The system is dark
-      // only, so one value is the whole answer.
-      { name: "theme-color", content: "#08090a" },
+      // The browser chrome takes the page's own ground. This surface pins
+      // the dark scheme, so one value is the whole answer.
+      { name: "theme-color", content: "#0d0b09" },
       { property: "og:image", content: ogImage },
       { property: "og:image:width", content: "1200" },
       { property: "og:image:height", content: "630" },

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -30,69 +30,69 @@
    tint of ember, and a bubble a step off the canvas.
 
    Five light values were drawn by eye and fail WCAG AA when measured, so the
-   measured ones ship instead: accent #c24a09 rather than #dd530e, code
+   measured ones ship instead: accent #bc4708 rather than #dd530e, code
    #9d4a0b rather than #b4550d, the three states one step darker, and ink-3
-   #686b71.
+   #6d6353.
 
    ink-3 is the fifth and the ticket's table does not carry it. The ticket
    corrected the mock's #8f9297 to #6e7177 and measured it on canvas and on
    surface, where it passes. It is also drawn on inset — every hovered sidebar
    row, the active row, the wrote strip — and inset is the darkest of the three
-   light grounds, where #6e7177 reads 4.25:1 and fails. The floor is measured
-   against the darkest ground it lands on, so it moves one step down: #686b71
-   reads 4.64:1 on inset, 4.97:1 on canvas and 5.34:1 on surface.
+   light grounds, where #6e7177 reads 4.01:1 and fails. The floor is measured
+   against the darkest ground it lands on, so it moves one step down: #6d6353
+   reads 4.83:1 on inset, 5.38:1 on canvas and 5.90:1 on surface.
 
    contrast.test.ts holds all of it, so nobody restores a value by eye.
 */
 :root {
   color-scheme: light;
 
-  --page: #eef0ef;
-  --canvas: #f6f7f6;
+  --page: #efeae2;
+  --canvas: #f7f4ef;
   --surface: #ffffff;
-  --inset: #efefed;
-  --border: #e4e4e0;
-  --border-strong: #d6d6d1;
-  --ink: #1b1c1e;
-  --ink-2: #55575c;
-  --ink-3: #686b71;
-  --accent: #c24a09;
+  --inset: #ede8df;
+  --border: #e5dfd4;
+  --border-strong: #d2cabb;
+  --ink: #272119;
+  --ink-2: #57503f;
+  --ink-3: #6d6353;
+  --accent: #bc4708;
   --accent-ink: #ffffff;
   --code: #9d4a0b;
-  --code-bg: #f1efec;
+  --code-bg: #f0ebe2;
   --ok: #1a7a33;
   --err: #c03434;
-  --run: #0a7c8c;
-  --bubble: #ececea;
+  --run: #087280;
+  --bubble: #f0ece4;
 
   /*
      The light skin may shadow exactly two things: the composer card and a
      genuinely detached overlay. The dark skin carries no shadow anywhere —
      depth there is a tonal step and a hairline.
   */
-  --shadow: 0 1px 2px rgb(27 28 30 / 0.05), 0 8px 24px rgb(27 28 30 / 0.06);
+  --shadow: 0 1px 2px rgb(39 33 25 / 0.05), 0 8px 24px rgb(39 33 25 / 0.06);
 }
 
 .dark {
   color-scheme: dark;
 
-  --page: #08090a;
-  --canvas: #0c0d0e;
-  --surface: #0f1011;
-  --inset: #161718;
-  --border: #23252a;
-  --border-strong: #383b3f;
-  --ink: #e5e5e6;
-  --ink-2: #b8bdc5;
-  --ink-3: #8a8f98;
+  --page: #0d0b09;
+  --canvas: #110e0b;
+  --surface: #14110e;
+  --inset: #1c1815;
+  --border: #2b2620;
+  --border-strong: #453d33;
+  --ink: #e9e5de;
+  --ink-2: #c2b9ac;
+  --ink-3: #988d7d;
   --accent: #ee6018;
-  --accent-ink: #08090a;
+  --accent-ink: #0d0b09;
   --code: #ee9a63;
-  --code-bg: #161718;
+  --code-bg: #1c1815;
   --ok: #27a644;
   --err: #eb5757;
   --run: #02b8cc;
-  --bubble: #1c1d1f;
+  --bubble: #211d18;
   --shadow: none;
 }
 

--- a/apps/web/src/themes.tsx
+++ b/apps/web/src/themes.tsx
@@ -26,8 +26,8 @@ export const THEMES: readonly ThemeInfo[] = [
     id: "default",
     name: "Default",
     colors: {
-      foreground: "#e5e5e6",
-      muted: "#8a8f98",
+      foreground: "#e9e5de",
+      muted: "#988d7d",
       accent: "#ee6018",
       warning: "#02b8cc",
     },

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -16,9 +16,9 @@ export const Route = createRootRoute({
     meta: [
       { charSet: "utf-8" },
       { name: "viewport", content: "width=device-width, initial-scale=1" },
-      // The browser chrome takes the page's own ground. The system is dark
-      // only, so one value is the whole answer.
-      { name: "theme-color", content: "#08090a" },
+      // The browser chrome takes the page's own ground. This surface pins
+      // the dark scheme, so one value is the whole answer.
+      { name: "theme-color", content: "#0d0b09" },
       { property: "og:image", content: ogImage },
       { property: "og:image:width", content: "1200" },
       { property: "og:image:height", content: "630" },

--- a/docs/design.md
+++ b/docs/design.md
@@ -4,28 +4,30 @@ name: Eva
 description: >-
   Eva is an open-source, autonomous software factory whose product is a terminal program.
   Every surface it owns — the terminal, the product app, the marketing site,
-  the documentation — is one dark instrument panel: a near-black canvas, a
-  sans that carries prose and a mono that carries machine output, and one
-  ember signal doing all the chromatic work.
+  the documentation — is one warm instrument panel: a near-black canvas by
+  default with a paper twin that fills the same roles, a sans that carries
+  prose and a mono that carries machine output, and one ember signal doing
+  all the chromatic work.
 colors:
-  void: "#08090a"
-  carbon: "#0f1011"
-  obsidian: "#161718"
-  graphite: "#23252a"
-  smoke: "#383b3f"
-  ash: "#62666d"
-  fog: "#8a8f98"
-  mist: "#d0d6e0"
-  bone: "#e5e5e6"
+  void: "#0d0b09"
+  carbon: "#14110e"
+  obsidian: "#1c1815"
+  graphite: "#2b2620"
+  smoke: "#453d33"
+  ash: "#6e6558"
+  fog: "#988d7d"
+  mist: "#d9d2c7"
+  bone: "#e9e5de"
   paper: "#ffffff"
 
   primary: "#ee6018"
+  primary-ink: "#0d0b09"
   teal: "#02b8cc"
   green: "#27a644"
   red: "#eb5757"
 
-  terminal-fg: "#e5e5e6"
-  terminal-muted: "#8a8f98"
+  terminal-fg: "#e9e5de"
+  terminal-muted: "#988d7d"
   terminal-accent: "#ee6018"
   terminal-warning: "#02b8cc"
 typography:
@@ -137,7 +139,7 @@ spacing:
 components:
   button-primary:
     backgroundColor: "{colors.primary}"
-    textColor: "{colors.void}"
+    textColor: "{colors.primary-ink}"
     typography: "{typography.button}"
     rounded: "{rounded.md}"
     padding: "{spacing.8} {spacing.16}"
@@ -333,21 +335,29 @@ components:
 Eva is an open-source, autonomous software factory. It runs coding work end to
 end, from a spec a machine can check to evidence that it was done. The design
 brief is the line the product prints in its own banner — **evidence, not
-claims** — and the surface is the instrument that prints it: a near-black
-panel, quiet neutrals, and one ember signal spent only where something is
-actually happening.
+claims** — and the surface is the instrument that prints it: a warm
+near-black panel, quiet neutrals, and one ember signal spent only where
+something is actually happening.
 
 **Key characteristics:**
 
-- **Dark only.** There is no light scheme, no theme toggle, no scheme cookie.
-- **Near-black, not black.** The canvas is `{colors.void}` `#08090a`. Pure
+- **Two schemes, one canon.** The dark scheme is canonical: the front matter
+  above carries it, and a surface that says nothing gets it. A light scheme
+  refills the same ten roles — raised is still lighter than the ground, the
+  floor ink is still the floor — so a component built on the ladder flips
+  without a scheme branch of its own. A surface pins one scheme or offers
+  the choice; a component never decides.
+- **Near-black, not black.** The canvas is `{colors.void}` `#0d0b09`. Pure
   `#000000` reaches 21:1 against white, and that much contrast haloes on OLED
-  and smears text in motion. `#08090a` gives up 1.1 points of contrast and
+  and smears text in motion. `#0d0b09` gives up 1.4 points of contrast and
   buys back a surface a reader can hold for an hour.
+- **Warm on purpose.** The neutrals carry a faint ember cast — the panel
+  sits with the accent rather than against it — held at a chroma low enough
+  that a full screen of it still reads neutral.
 - **Two faces, one rule.** Geist carries prose and UI; Geist Mono carries
   anything a machine produced — code, transcripts, labels, metadata. They are
   one family, so their metrics agree.
-- **Ink is `{colors.bone}` `#e5e5e6`, not white.** Paper white is reserved for
+- **Ink is `{colors.bone}` `#e9e5de`, not white.** Paper white is reserved for
   the hero and inline emphasis. Full-strength white as the default ink is the
   same halation problem as a pure black ground, from the other side.
 - **One chromatic signal**, `{colors.primary}` `#ee6018`, plus three states
@@ -361,56 +371,62 @@ actually happening.
 ## Colors
 
 Ten neutrals, one accent, three states, and the four names the terminal
-contract reads. Every ratio below is measured, not estimated.
+contract reads. Every ratio below is measured, not estimated — in both
+schemes.
 
 ### Why these neutrals
 
 This ladder was measured against the alternatives and kept because it is the
 only one with a genuinely distinct step at every job — two grounds, two
-borders and four inks — and because its neutrals carry a faint blue cast that
-keeps a large dark field from reading brown.
+borders and four inks. Its neutrals carry a faint ember cast on purpose: the
+panel sits with the accent rather than against it. The risk a warm dark
+field runs — reading muddy at size — is held off by keeping the cast's
+chroma low and by measuring every step, which is the same discipline the
+cool ladder it replaced was held to.
 
 ### Surfaces
 
-- **Void** (`{colors.void}` — `#08090a`): the page, the nav, the footer.
-- **Carbon** (`{colors.carbon}` — `#0f1011`): the raised surface — cards, the
+- **Void** (`{colors.void}` — `#0d0b09`): the page, the nav, the footer.
+- **Carbon** (`{colors.carbon}` — `#14110e`): the raised surface — cards, the
   transcript panel, code blocks, the announcement strip.
-- **Obsidian** (`{colors.obsidian}` — `#161718`): the elevated surface —
+- **Obsidian** (`{colors.obsidian}` — `#1c1815`): the elevated surface —
   popovers, menus, secondary buttons, inline code, avatars.
 
 ### Lines
 
-- **Graphite** (`{colors.graphite}` — `#23252a`): the hairline, at 1.30:1 on
+- **Graphite** (`{colors.graphite}` — `#2b2620`): the hairline, at 1.31:1 on
   void. Separation between two static surfaces, and never the thing that
   identifies a control.
-- **Smoke** (`{colors.smoke}` — `#383b3f`): the same edge under hover or
-  focus, at 1.77:1.
-- **Ash** (`{colors.ash}` — `#62666d`): the control boundary, at **3.45:1** —
+- **Smoke** (`{colors.smoke}` — `#453d33`): the same edge under hover or
+  focus, at 1.84:1.
+- **Ash** (`{colors.ash}` — `#6e6558`): the control boundary, at **3.43:1** —
   the only line in the ladder that clears the 3:1 SC 1.4.11 asks of a non-text
-  edge. As text it **fails at 3.45:1**, so ash marks an inactive tab or a
+  edge. As text it **fails at 3.43:1**, so ash marks an inactive tab or a
   disabled label and nothing that has to be read.
 
 ### Text
 
-- **Bone** (`{colors.bone}` — `#e5e5e6`): the default ink, at **15.83:1** on
-  void, 15.13:1 on carbon, 14.26:1 on obsidian.
-- **Mist** (`{colors.mist}` — `#d0d6e0`): bright secondary — navigation links,
-  dense UI rows, inline code, the hero lede — at **13.64:1**.
-- **Fog** (`{colors.fog}` — `#8a8f98`): secondary prose, captions, eyebrows
-  and metadata, at **6.13:1** on void and 5.52:1 on obsidian. **Fog is the
+- **Bone** (`{colors.bone}` — `#e9e5de`): the default ink, at **15.65:1** on
+  void, 14.99:1 on carbon, 14.05:1 on obsidian.
+- **Mist** (`{colors.mist}` — `#d9d2c7`): bright secondary — navigation links,
+  dense UI rows, inline code, the hero lede — at **13.09:1**.
+- **Fog** (`{colors.fog}` — `#988d7d`): secondary prose, captions, eyebrows
+  and metadata, at **6.03:1** on void and 5.41:1 on obsidian. **Fog is the
   text floor.** Nothing quieter may carry text.
 - **Paper** (`{colors.paper}` — `#ffffff`): the hero headline and inline
-  emphasis only, at 19.93:1. It is a highlight, not a default.
+  emphasis only, at 19.65:1. It is a highlight, not a default.
 
 ### The accent
 
-- **Ember** (`{colors.primary}` — `#ee6018`): the signal orange, taken over
-  the `#da5c2c` alternative on the measurement — **6.00:1** against void where
-  that one reaches 5.27:1, and the same 6.00:1 for the ink sitting on the
-  fill.
-- **The ink on an ember fill is `{colors.void}`.** Bone on ember measures
-  **2.64:1** and fails outright; void measures 6.00:1. Every dark interface we
-  measured puts a light ink on its orange, and every one of them is wrong.
+- **Ember** (`{colors.primary}` — `#ee6018`): the signal orange, at
+  **5.91:1** against void — above the 4.5:1 AA asks of it as text, and well
+  above the 3:1 it needs as the focus ring.
+- **The ink on an ember fill is `{colors.primary-ink}`, never the ladder's.**
+  Bone on ember measures **2.65:1** and fails outright; the fill ink is its
+  own token because it does not follow the scheme flip — near-black on the
+  dark scheme's ember, white on the light scheme's darker one. Every dark
+  interface we measured puts a light ink on its orange, and every one of
+  them is wrong.
 - Ember fills the primary CTA, draws the 2 px editorial case mark, colours the
   shipping stage tag and the transcript's turn marker, and paints the focus
   ring. **Nothing else.** Scattered onto ordinary text, icons or borders it
@@ -421,23 +437,60 @@ keeps a large dark field from reading brown.
 These report what a machine did, and only that. They never decorate chrome.
 
 - **Teal** (`{colors.teal}` — `#02b8cc`): running, in progress, and the
-  log-bar histogram — at **8.29:1**, the most legible data colour of the
+  log-bar histogram — at **8.17:1**, the most legible data colour of the
   candidates measured.
 - **Green** (`{colors.green}` — `#27a644`): a passing check, a clean diff, at
-  **6.29:1**.
+  **6.20:1**.
 - **Red** (`{colors.red}` — `#eb5757`): a failing check, a destructive action,
-  at **5.73:1**.
+  at **5.64:1**.
 
 Status colour never carries meaning alone; the text names the state and a
 symbol confirms it.
+
+### The light scheme
+
+The same ten jobs, refilled. The ground is a warm paper rather than an
+inverted grey, raised surfaces still step **lighter** than the ground — so
+elevation reads the same way in both schemes — and the floor ink is still
+the floor. Chromatic signals deepen rather than swap: the light ember and
+the light states are darker cuts of the same hues, because a colour legible
+on a near-black ground is not legible on paper.
+
+| Role          | Dark (canonical) | Light     | Light verdict                         |
+| ------------- | ---------------- | --------- | ------------------------------------- |
+| `void`        | `#0d0b09`        | `#f7f4ef` | The page                              |
+| `carbon`      | `#14110e`        | `#fcfaf7` | The raised surface                    |
+| `obsidian`    | `#1c1815`        | `#ffffff` | The elevated surface                  |
+| `graphite`    | `#2b2620`        | `#e8e2d8` | Hairline, 1.17:1                      |
+| `smoke`       | `#453d33`        | `#d6cec1` | Hover edge, 1.42:1                    |
+| `ash`         | `#6e6558`        | `#8b8172` | Control boundary, 3.49:1 — never text |
+| `fog`         | `#988d7d`        | `#6d6353` | The text floor, 5.38:1                |
+| `mist`        | `#d9d2c7`        | `#514a3f` | Bright secondary, 7.97:1              |
+| `bone`        | `#e9e5de`        | `#272119` | The default ink, 14.52:1              |
+| `paper`       | `#ffffff`        | `#100d0a` | Emphasis only, 17.66:1                |
+| `primary`     | `#ee6018`        | `#bc4708` | The accent, 4.73:1                    |
+| `primary-ink` | `#0d0b09`        | `#ffffff` | The CTA ink, 5.19:1 on its fill       |
+| `teal`        | `#02b8cc`        | `#087280` | Running, 5.13:1                       |
+| `green`       | `#27a644`        | `#1a7a33` | Passed, 4.94:1                        |
+| `red`         | `#eb5757`        | `#c03434` | Failed, 5.06:1                        |
+
+Light ratios are measured on the light void; the full grid is in the table
+below. Two rules keep the flip honest:
+
+- **A component never carries a scheme branch.** It reads the ladder, and
+  the scheme class on the root refills the ladder. A `dark:` utility in
+  component code is a defect.
+- **A surface pins a scheme or offers the choice, at its root, once.** The
+  terminal stays dark; the marketing site pins dark; a reading surface may
+  offer both.
 
 ### Terminal contract
 
 The renderer contract names four colours, and a theme fills every one and no
 more. They are the same values the rest of the system uses:
 
-- `{colors.terminal-fg}` `#e5e5e6` — a person's words and the agent's words.
-- `{colors.terminal-muted}` `#8a8f98` — reasoning and anything secondary.
+- `{colors.terminal-fg}` `#e9e5de` — a person's words and the agent's words.
+- `{colors.terminal-muted}` `#988d7d` — reasoning and anything secondary.
 - `{colors.terminal-accent}` `#ee6018` — the bar beside a person's turn.
 - `{colors.terminal-warning}` `#02b8cc` — tool output. The contract's key is
   named `warning` for historical reasons; the colour is teal, because tool
@@ -445,21 +498,40 @@ more. They are the same values the rest of the system uses:
 
 ### Measured contrast
 
-| Ink                  | on void | on carbon | on obsidian | Verdict                      |
-| -------------------- | ------- | --------- | ----------- | ---------------------------- |
-| `paper` `#ffffff`    | 19.93   | 19.05     | 17.95       | Emphasis only                |
-| `bone` `#e5e5e6`     | 15.83   | 15.13     | 14.26       | The default ink              |
-| `mist` `#d0d6e0`     | 13.64   | 13.04     | 12.29       | Bright secondary             |
-| `fog` `#8a8f98`      | 6.13    | 5.86      | 5.52        | The text floor               |
-| `ash` `#62666d`      | 3.45    | 3.30      | 3.11        | **Never text.** Borders only |
-| `smoke` `#383b3f`    | 1.77    | 1.69      | 1.59        | Line                         |
-| `graphite` `#23252a` | 1.30    | 1.24      | 1.17        | Hairline                     |
-| `primary` `#ee6018`  | 6.00    | 5.73      | —           | The accent                   |
-| `teal` `#02b8cc`     | 8.29    | 7.92      | —           | Running, log bars            |
-| `green` `#27a644`    | 6.29    | 6.01      | —           | Passed                       |
-| `red` `#eb5757`      | 5.73    | 5.47      | —           | Failed                       |
-| `void` on ember      | 6.00    | —         | —           | The CTA ink                  |
-| `bone` on ember      | 2.64    | —         | —           | **A defect. Never.**         |
+The dark scheme:
+
+| Ink                    | on void | on carbon | on obsidian | Verdict                      |
+| ---------------------- | ------- | --------- | ----------- | ---------------------------- |
+| `paper` `#ffffff`      | 19.65   | 18.81     | 17.63       | Emphasis only                |
+| `bone` `#e9e5de`       | 15.65   | 14.99     | 14.05       | The default ink              |
+| `mist` `#d9d2c7`       | 13.09   | 12.54     | 11.75       | Bright secondary             |
+| `fog` `#988d7d`        | 6.03    | 5.77      | 5.41        | The text floor               |
+| `ash` `#6e6558`        | 3.43    | 3.28      | 3.08        | **Never text.** Borders only |
+| `smoke` `#453d33`      | 1.84    | 1.76      | 1.65        | Line                         |
+| `graphite` `#2b2620`   | 1.31    | 1.25      | 1.18        | Hairline                     |
+| `primary` `#ee6018`    | 5.91    | 5.66      | —           | The accent                   |
+| `teal` `#02b8cc`       | 8.17    | 7.82      | —           | Running, log bars            |
+| `green` `#27a644`      | 6.20    | 5.93      | —           | Passed                       |
+| `red` `#eb5757`        | 5.64    | 5.40      | —           | Failed                       |
+| `primary-ink` on ember | 5.91    | —         | —           | The CTA ink                  |
+| `bone` on ember        | 2.65    | —         | —           | **A defect. Never.**         |
+
+The light scheme, on its own three grounds:
+
+| Ink                    | on void | on carbon | on obsidian | Verdict                      |
+| ---------------------- | ------- | --------- | ----------- | ---------------------------- |
+| `paper` `#100d0a`      | 17.66   | 18.59     | 19.37       | Emphasis only                |
+| `bone` `#272119`       | 14.52   | 15.29     | 15.94       | The default ink              |
+| `mist` `#514a3f`       | 7.97    | 8.39      | 8.75        | Bright secondary             |
+| `fog` `#6d6353`        | 5.38    | 5.66      | 5.90        | The text floor               |
+| `ash` `#8b8172`        | 3.49    | 3.68      | 3.83        | **Never text.** Borders only |
+| `smoke` `#d6cec1`      | 1.42    | 1.50      | 1.56        | Line                         |
+| `graphite` `#e8e2d8`   | 1.17    | 1.24      | 1.29        | Hairline                     |
+| `primary` `#bc4708`    | 4.73    | 4.99      | 5.19        | The accent                   |
+| `teal` `#087280`       | 5.13    | 5.41      | 5.63        | Running, log bars            |
+| `green` `#1a7a33`      | 4.94    | 5.20      | 5.42        | Passed                       |
+| `red` `#c03434`        | 5.06    | 5.33      | 5.55        | Failed                       |
+| `primary-ink` on ember | 5.19    | —         | —           | The CTA ink                  |
 
 ## Typography
 
@@ -588,10 +660,12 @@ Nothing between the steps, and nothing outside them. A one-off such as
 | 2     | `{colors.obsidian}` | Tonal step plus hairline.                       | Popovers, menus, secondary buttons. |
 | —     | Focus               | 2 px `{colors.primary}` outline, 2 px offset.   | Every focusable element.            |
 
-Elevation is a tonal step and a hairline. The one exception is an element that
-genuinely detaches from the page — a popover or a menu over content — which
-may carry `rgba(8, 9, 10, 0.6) 0 4px 32px`. A card never casts, and no shadow
-is ever used to make a flat surface look raised.
+Elevation is a tonal step and a hairline, and the step runs **lighter as it
+rises in both schemes**, so raised means one thing everywhere. The one
+exception is an element that genuinely detaches from the page — a popover or
+a menu over content — which may carry `rgba(13, 11, 9, 0.6) 0 4px 32px`. A
+card never casts, and no shadow is ever used to make a flat surface look
+raised.
 
 ## Shapes
 
@@ -760,7 +834,9 @@ ship: high contrast, and monochrome for terminals without colour.
 - Keep `{colors.fog}` as the floor for anything meant to be read.
 - Use `{colors.ash}` for a control's edge and an inactive label — never for
   text a reader has to take in.
-- Put `{colors.void}` ink on an ember fill. Bone measures 2.64:1 there.
+- Put `{colors.primary-ink}` on an ember fill, in both schemes. Bone measures
+  2.65:1 there and the ladder inks flip with the ground, so the fill ink is
+  its own token.
 - Spend `{colors.primary}` on the CTA, the case mark, the shipping tag, the
   turn marker and the focus ring, and nowhere else.
 - Report a machine outcome with a glyph, a word, and then the colour.
@@ -778,12 +854,16 @@ ship: high contrast, and monochrome for terminals without colour.
   aesthetic gets wrong, and this system does not repeat it.
 - Don't use pure `#000000` as a ground or pure `#ffffff` as the default ink.
 - Don't set text in `{colors.ash}`, or in anything below `{colors.fog}`.
-- Don't put a light ink on the ember fill.
+- Don't put a ladder ink on the ember fill; the fill ink is `primary-ink`.
 - Don't scatter `{colors.primary}` onto ordinary text, icons or borders.
 - Don't use `{colors.teal}`, `{colors.green}` or `{colors.red}` for chrome, or
   as a filled status badge.
 - Don't introduce a second accent to rank two kinds of importance.
-- Don't add a light-theme section, a scheme toggle, or an alternate ground.
+- Don't write a scheme branch in a component — no `dark:` utility, no
+  per-scheme value outside the two ladder blocks. The root's scheme class is
+  the only place the flip happens.
+- Don't invent a third scheme, or remap single tokens per surface; a surface
+  pins dark, pins light, or offers the two.
 - Don't put a shadow under a card, or use one to fake elevation anywhere
   except a genuinely detached overlay.
 - Don't put a gradient anywhere.

--- a/docs/ui-guidelines.md
+++ b/docs/ui-guidelines.md
@@ -50,16 +50,16 @@ cost of conforming instead — or resolved in favour of the house rule.
 
 ## 1. Context and goals
 
-| Item                 | Value                                                             |
-| -------------------- | ----------------------------------------------------------------- |
-| Product              | Eva, an open-source autonomous software factory                   |
-| Publisher            | missing studio                                                    |
-| Surfaces             | `evafactory.co` (marketing), `docs.evafactory.co` (documentation) |
-| Stack                | TanStack Start, Tailwind v4, shared `@missingstudio/ui`           |
-| Documentation layer  | Fumadocs 16, notebook layout                                      |
-| Audience             | Developers and technical teams                                    |
-| Accessibility target | WCAG 2.2 AA                                                       |
-| Style                | Structured, tokenized, content-first, dark only                   |
+| Item                 | Value                                                                  |
+| -------------------- | ---------------------------------------------------------------------- |
+| Product              | Eva, an open-source autonomous software factory                        |
+| Publisher            | missing studio                                                         |
+| Surfaces             | `evafactory.co` (marketing), `docs.evafactory.co` (documentation)      |
+| Stack                | TanStack Start, Tailwind v4, shared `@missingstudio/ui`                |
+| Documentation layer  | Fumadocs 16, notebook layout                                           |
+| Audience             | Developers and technical teams                                         |
+| Accessibility target | WCAG 2.2 AA                                                            |
+| Style                | Structured, tokenized, content-first, dark canonical with a light twin |
 
 Goals, in priority order:
 
@@ -131,11 +131,11 @@ must report **0 errors and 0 warnings**. Three rules of the format shape what
 the front matter can hold, and all three are followed rather than worked
 around:
 
-| Rule of the format         | What it means here                                                                                                                                                         |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Every colour is bound      | A colour no component references is an orphan. Ours are the ten neutrals — `void` through `paper` — plus `primary` and the three states, and each is bound to a component. |
-| One scheme                 | The format has no scheme dimension, and the system is dark only, so the front matter carries the whole palette. There is no second scheme anywhere.                        |
-| Eight component sub-tokens | Only `backgroundColor`, `textColor`, `typography`, `rounded`, `padding`, `size`, `height`, `width` exist. Borders, gradients and motion are prose, not component tokens.   |
+| Rule of the format         | What it means here                                                                                                                                                                                |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Every colour is bound      | A colour no component references is an orphan. Ours are the ten neutrals — `void` through `paper` — plus `primary` and the three states, and each is bound to a component.                        |
+| One scheme                 | The format has no scheme dimension, so the front matter carries the canonical dark palette. The light twins live in prose (design.md's light table) and in tokens.css, never in the front matter. |
+| Eight component sub-tokens | Only `backgroundColor`, `textColor`, `typography`, `rounded`, `padding`, `size`, `height`, `width` exist. Borders, gradients and motion are prose, not component tokens.                          |
 
 A warning is a defect. Do not add a token the format cannot carry and then
 explain the warning away; either express it within these three rules or keep
@@ -149,13 +149,13 @@ an alternative is named it is named as a value, because a value can be
 re-measured and a preference cannot.
 
 **The ground.** A pure `#000000` canvas reaches 21:1 against white — enough
-contrast to halo on OLED and smear text in motion. **Resolution:** `#08090a`,
-at 19.93:1 against paper and 15.83:1 against the default ink. It gives up
+contrast to halo on OLED and smear text in motion. **Resolution:** `#0d0b09`,
+at 19.65:1 against paper and 15.65:1 against the default ink. It gives up
 about a point of contrast and buys back a surface a reader can hold for an
 hour.
 
 **The default ink.** A maximum-contrast white ink is the same halation problem
-from the other side. **Resolution:** bone `#e5e5e6` at 15.83:1 is the default;
+from the other side. **Resolution:** bone `#e9e5de` at 15.65:1 is the default;
 paper `#ffffff` is reserved for the hero headline and inline emphasis.
 
 **The faces.** Setting everything in a monospaced face measurably slows
@@ -164,17 +164,22 @@ continuous reading — which is most of what the documentation surface is.
 are one family, so the metrics agree, and both are on the house-rules allowed
 list where Berkeley Mono and Inter are not.
 
-**The accent.** A `#da5c2c` ember measures 5.27:1 on the ground; `#ee6018`
-measures **6.00:1**. **Resolution:** `#ee6018`, kept under the name ember.
+**The accent.** `#ee6018` measures **5.91:1** on the dark ground, above both
+the 4.5:1 it needs as text and the 3:1 it needs as the focus ring. On the
+light ground it fails as text, so the light scheme deepens it to `#bc4708`
+at 4.73:1. **Resolution:** one accent per scheme, both under the name ember.
 
-**The CTA ink.** A light ink on an orange fill is the common choice, and it
-fails: bone on ember measures **2.64:1**. **Resolution:** the ink on an ember
-fill is void, at 6.00:1.
+**The CTA ink.** A ladder ink on the ember fill fails twice: bone on the dark
+ember measures **2.65:1**, and a ladder ink flips with the scheme while the
+fill's needs do not. **Resolution:** the fill ink is its own token,
+`primary-ink` — near-black `#0d0b09` on the dark ember at 5.91:1, white on
+the light ember at 5.19:1.
 
-**The neutral ladder.** A ladder earns its place by holding a distinct step at
-every job — three grounds, three lines, four inks — and by carrying a faint
-blue cast, which keeps a large dark field from reading brown. **Resolution:**
-the ten neutrals in [design.md](design.md), taken whole and unchanged.
+**The neutral ladder.** A ladder earns its place by holding a distinct step
+at every job — three grounds, three lines, four inks. The cast is a faint
+ember warmth, chosen so the panel sits with the accent, and held at a chroma
+low enough that a full field still reads neutral. **Resolution:** the ten
+neutrals in [design.md](design.md), taken whole per scheme.
 
 **The radius.** A 2px radius everywhere reads as an unfinished rectangle on a
 36px control. **Resolution:** the range — 2px for small nested shapes, 6px for
@@ -187,32 +192,37 @@ tighter discipline: -0.011em at reading sizes, -0.022em at display sizes.
 
 ### 2.3 Color
 
-The system is dark only. There is no light scheme, no theme control, no
-scheme cookie, and no component may carry a `dark:` branch of its own — the
-`dark` class is pinned on every root element solely so the shadcn components'
-existing variants stay live.
+The system carries two schemes over one ladder. Dark is canonical: the bare
+tokens hold its values, and a root that says nothing gets it. A root carrying
+`.light` refills every token with its light twin, and `.dark` re-asserts the
+canon so a dark island can sit inside a light page. No component may carry a
+`dark:` branch of its own — the scheme class on the root is the only place
+the flip happens, and the class also keeps the shadcn components' existing
+variants live. A surface pins one scheme or offers the choice; a component
+never decides.
 
 One color has three names: the semantic name used in this file, the token
 name used in design.md, and the CSS custom property that ships. They are
 listed side by side because that is the only way the three stay welded
 together.
 
-| Semantic token         | design.md token | CSS property       | Value     |
-| ---------------------- | --------------- | ------------------ | --------- |
-| `color.surface.base`   | `void`          | `--color-void`     | `#08090a` |
-| `color.surface.raised` | `carbon`        | `--color-carbon`   | `#0f1011` |
-| `color.surface.high`   | `obsidian`      | `--color-obsidian` | `#161718` |
-| `color.border.default` | `graphite`      | `--color-graphite` | `#23252a` |
-| `color.border.strong`  | `smoke`         | `--color-smoke`    | `#383b3f` |
-| `color.border.control` | `ash`           | `--color-ash`      | `#62666d` |
-| `color.text.tertiary`  | `fog`           | `--color-fog`      | `#8a8f98` |
-| `color.text.secondary` | `mist`          | `--color-mist`     | `#d0d6e0` |
-| `color.text.primary`   | `bone`          | `--color-bone`     | `#e5e5e6` |
-| `color.text.emphasis`  | `paper`         | `--color-paper`    | `#ffffff` |
-| `color.accent`         | `primary`       | `--color-ember`    | `#ee6018` |
-| `color.state.running`  | `teal`          | `--color-teal`     | `#02b8cc` |
-| `color.state.ok`       | `green`         | `--color-green`    | `#27a644` |
-| `color.state.fail`     | `red`           | `--color-red`      | `#eb5757` |
+| Semantic token         | design.md token | CSS property        | Dark      | Light     |
+| ---------------------- | --------------- | ------------------- | --------- | --------- |
+| `color.surface.base`   | `void`          | `--color-void`      | `#0d0b09` | `#f7f4ef` |
+| `color.surface.raised` | `carbon`        | `--color-carbon`    | `#14110e` | `#fcfaf7` |
+| `color.surface.high`   | `obsidian`      | `--color-obsidian`  | `#1c1815` | `#ffffff` |
+| `color.border.default` | `graphite`      | `--color-graphite`  | `#2b2620` | `#e8e2d8` |
+| `color.border.strong`  | `smoke`         | `--color-smoke`     | `#453d33` | `#d6cec1` |
+| `color.border.control` | `ash`           | `--color-ash`       | `#6e6558` | `#8b8172` |
+| `color.text.tertiary`  | `fog`           | `--color-fog`       | `#988d7d` | `#6d6353` |
+| `color.text.secondary` | `mist`          | `--color-mist`      | `#d9d2c7` | `#514a3f` |
+| `color.text.primary`   | `bone`          | `--color-bone`      | `#e9e5de` | `#272119` |
+| `color.text.emphasis`  | `paper`         | `--color-paper`     | `#ffffff` | `#100d0a` |
+| `color.accent`         | `primary`       | `--color-ember`     | `#ee6018` | `#bc4708` |
+| `color.accent.ink`     | `primary-ink`   | `--color-ember-ink` | `#0d0b09` | `#ffffff` |
+| `color.state.running`  | `teal`          | `--color-teal`      | `#02b8cc` | `#087280` |
+| `color.state.ok`       | `green`         | `--color-green`     | `#27a644` | `#1a7a33` |
+| `color.state.fail`     | `red`           | `--color-red`       | `#eb5757` | `#c03434` |
 
 The custom properties live in Tailwind's `@theme`, so each answers as a
 utility: `bg-void`, `bg-carbon`, `bg-obsidian`, `border-graphite`,
@@ -222,32 +232,35 @@ The shadcn bridge in `shadcn.css` maps shadcn's own names
 the same properties, so a registry component and a hand-built one read one
 palette.
 
-Measured contrast, sRGB:
+Measured contrast, sRGB, the dark scheme (the light grid is in design.md's
+light table; both are held by the same discipline):
 
 | Ink                     | On void  | On carbon | On obsidian | Verdict                      |
 | ----------------------- | -------- | --------- | ----------- | ---------------------------- |
-| `paper`                 | 19.93    | 19.05     | 17.95       | Emphasis only                |
-| `bone`                  | 15.83    | 15.13     | 14.26       | The default ink              |
-| `mist`                  | 13.64    | 13.04     | 12.29       | Bright secondary             |
-| `fog`                   | 6.13     | 5.86      | 5.52        | The text floor               |
-| `ash`                   | **3.45** | 3.30      | 3.11        | **Never text.** Borders only |
-| `smoke`                 | 1.77     | 1.69      | 1.59        | Line                         |
-| `graphite`              | 1.30     | 1.24      | 1.17        | Hairline                     |
-| `ember`                 | 6.00     | 5.73      | —           | The accent                   |
-| `teal`                  | 8.29     | 7.92      | —           | Running, log bars            |
-| `green`                 | 6.29     | 6.01      | —           | Passed                       |
-| `red`                   | 5.73     | 5.47      | —           | Failed                       |
-| `void` on an ember fill | 6.00     | —         | —           | The CTA ink                  |
-| `bone` on an ember fill | **2.64** | —         | —           | **Fails; never do this**     |
+| `paper`                 | 19.65    | 18.81     | 17.63       | Emphasis only                |
+| `bone`                  | 15.65    | 14.99     | 14.05       | The default ink              |
+| `mist`                  | 13.09    | 12.54     | 11.75       | Bright secondary             |
+| `fog`                   | 6.03     | 5.77      | 5.41        | The text floor               |
+| `ash`                   | **3.43** | 3.28      | 3.08        | **Never text.** Borders only |
+| `smoke`                 | 1.84     | 1.76      | 1.65        | Line                         |
+| `graphite`              | 1.31     | 1.25      | 1.18        | Hairline                     |
+| `ember`                 | 5.91     | 5.66      | —           | The accent                   |
+| `teal`                  | 8.17     | 7.82      | —           | Running, log bars            |
+| `green`                 | 6.20     | 5.93      | —           | Passed                       |
+| `red`                   | 5.64     | 5.40      | —           | Failed                       |
+| `primary-ink` on ember  | 5.91     | —         | —           | The CTA ink                  |
+| `bone` on an ember fill | **2.65** | —         | —           | **Fails; never do this**     |
 
 Binding consequences:
 
 - **Fog is the text floor.** No token may be added below it.
-- **Ash is never text.** At 3.45:1 it fails AA at every body size. It is the
+- **Ash is never text.** At 3.43:1 it fails AA at every body size. It is the
   control boundary and the inactive-tab label, and nothing else.
 - **Bone is the default ink, not paper.** Paper is the hero headline and
   inline emphasis.
-- **The ink on ember is void.** Bone on ember measures 2.64:1 and fails.
+- **The ink on ember is `primary-ink`, in both schemes.** Bone on ember
+  measures 2.65:1 and fails, and every ladder ink flips with the scheme
+  while the fill's needs do not.
 - **Ember is spent, not spread.** The primary CTA fill, the editorial card's
   2px left border, the shipping stage tag, the terminal turn marker, and the
   focus ring. Ordinary text, icons and borders never take it.
@@ -255,10 +268,10 @@ Binding consequences:
   bars, green is passed, red is failed. No button, border, link or label takes
   one, and there is no filled status badge — the glyph and the word carry the
   state, and the colour confirms it.
-- **A hairline is not a control boundary.** Graphite measures 1.30:1 on void —
+- **A hairline is not a control boundary.** Graphite measures 1.31:1 on void —
   correct for separating two static surfaces, and a fail under SC 1.4.11 for
   anything that needs an edge to be recognised as a control. An input's edge
-  is ash, at 3.45:1.
+  is ash, at 3.43:1.
 
 The boundary rule in one line: **a card may use a hairline, an input may not.**
 A card is identified by its content; an input is identified by its edge.
@@ -279,7 +292,7 @@ role instead, or read the one that names what this element is.
 
 Shadows do not carry depth. Depth is a hairline and a tonal step — void to
 carbon to obsidian. The one shadow the system carries,
-`rgba(8, 9, 10, 0.6) 0 4px 32px`, belongs to an element that genuinely
+`rgba(13, 11, 9, 0.6) 0 4px 32px`, belongs to an element that genuinely
 detaches from the page — a popover or a menu over content. A card never casts,
 and no shadow is ever used to make a flat surface look raised.
 
@@ -535,8 +548,8 @@ One focus treatment, both surfaces, every component:
   defect. There are no exceptions.
 - The 2px offset must not be clipped. An ancestor with `overflow: hidden` and
   a focusable descendant at its edge is a defect.
-- The ring measures 6.00:1 against the void, above the 3:1 that SC 1.4.11
-  requires.
+- The ring measures 5.91:1 against the dark void and 4.73:1 against the
+  light one, above the 3:1 that SC 1.4.11 requires in both schemes.
 
 It is authored once, in
 [packages/ui/src/styles/tokens.css](../packages/ui/src/styles/tokens.css),
@@ -570,7 +583,7 @@ does not ask for. Centre by eye and keep the nudge.
 and below 2px the inner shape stays square.
 
 **An image carries its own edge.** A dark capture on the void merges into it.
-Give it a 1px outline offset by `-1px` — white at 8% — which draws inside the
+Give it a 1px outline offset by `-1px` — the ink at 8% — which draws inside the
 box and never grows it. This is an outline, not a shadow, and it is the only
 edge an image gets.
 
@@ -798,8 +811,9 @@ heading when no observer runs.
 - A deep page tree must scroll inside the sidebar, not the page.
 - A heading longer than the TOC column must wrap to two lines, then clamp.
 - With one heading on a page the TOC must not render.
-- There is no theme control. The system is dark only, and a control that
-  offers a choice that does not exist is a defect.
+- A theme control appears only on a surface that ships both schemes, and it
+  offers exactly the two. A control that offers a choice that does not exist
+  is a defect.
 
 ### 3.7 Code block and command snippet — shared
 
@@ -1153,10 +1167,12 @@ Each of these is a defect, not a preference.
 
 - Any gradient: linear, radial or mesh, on a background or on text.
 - The purple and blue "AI gradient" aesthetic.
-- A light surface anywhere, pure `#000000` as a ground, or pure `#ffffff` as
-  the default ink.
-- Text below `fog`, or any text in `ash`; it measures 3.45:1.
-- Bone text on an ember fill; it measures 2.64:1.
+- A ground off the ladder, pure `#000000` as a ground, or maximum-contrast
+  emphasis ink as the default ink.
+- A scheme branch in component code; the root's scheme class owns the flip.
+- Text below `fog`, or any text in `ash`; it measures 3.43:1.
+- A ladder ink on an ember fill; bone there measures 2.65:1, and the fill
+  ink is `primary-ink`.
 - Ember on ordinary text, icons or borders — it belongs to the CTA fill, the
   case mark, the shipping stage tag, log bars and the focus ring.
 - `teal`, `green` or `red` on anything that is not a machine outcome.
@@ -1215,7 +1231,8 @@ Each of these is a defect, not a preference.
 - A mobile menu as a dropdown instead of a full overlay.
 - The `disabled` attribute where the reader needs to find the control.
 - A control that resizes when its own label changes.
-- A theme control of any kind. There is no theme to choose.
+- A theme control on a surface that pins one scheme. The control belongs
+  only where both schemes ship.
 - A target below 24×24 CSS pixels, or a hover-only affordance.
 - A circular spinner where a skeleton belongs, or `window.alert()` for an error.
 - A dead link pointing at `#`.

--- a/packages/tui-renderer/src/palette.ts
+++ b/packages/tui-renderer/src/palette.ts
@@ -13,11 +13,11 @@ export const DEFAULT_PALETTE: Palette = {
   // A person's words are bold, and the accent is the bar beside them. The
   // words themselves stay the reading colour. The values are docs/design.md's
   // terminal contract: bone, fog, ember, and teal for tool output.
-  human: "#e5e5e6",
-  agent: "#e5e5e6",
-  thought: "#8a8f98",
+  human: "#e9e5de",
+  agent: "#e9e5de",
+  thought: "#988d7d",
   tool: "#02b8cc",
-  muted: "#8a8f98",
+  muted: "#988d7d",
   accent: "#ee6018",
 }
 

--- a/packages/ui/src/styles/shadcn.css
+++ b/packages/ui/src/styles/shadcn.css
@@ -11,8 +11,9 @@
    own neutral scale, its own font, and its own `dark` variant, and importing
    it would replace the brand rather than bridge to it.
 
-   Import it after tokens.css. The system is dark only, so every mapping below
-   is a single value — there is no scheme to switch.
+   Import it after tokens.css. Every mapping below is a var() onto the
+   ladder, and the ladder flips by scheme class, so one mapping serves both
+   schemes — there is nothing here to switch.
 
    The one distinction worth keeping: the tokens split the graphite hairline
    between two static surfaces from the ash boundary that says "this is a
@@ -55,10 +56,11 @@
   --color-muted: var(--color-obsidian);
   --color-muted-foreground: var(--color-fog);
 
-  /* Ember carries primary. Its ink is void: bone on ember measures 2.64:1
-     and fails, void measures 6.00:1. */
+  /* Ember carries primary. Its ink is ember-ink, which does not follow the
+     ladder: near-black on the dark ember, white on the light one. Bone on
+     the dark ember measures 2.65:1 and fails. */
   --color-primary: var(--color-ember);
-  --color-primary-foreground: var(--color-void);
+  --color-primary-foreground: var(--color-ember-ink);
 
   /* Secondary is a filled quiet control, which is the elevated surface. */
   --color-secondary: var(--color-obsidian);
@@ -83,7 +85,7 @@
   --color-sidebar-accent: var(--color-obsidian);
   --color-sidebar-accent-foreground: var(--color-bone);
   --color-sidebar-primary: var(--color-ember);
-  --color-sidebar-primary-foreground: var(--color-void);
+  --color-sidebar-primary-foreground: var(--color-ember-ink);
   --color-sidebar-ring: var(--color-ember);
 }
 

--- a/packages/ui/src/styles/surfaces.css
+++ b/packages/ui/src/styles/surfaces.css
@@ -257,11 +257,12 @@
 
   /*
      An image sits on the page with no edge of its own, so a dark capture on
-     the void merges. A hairline of bone at 8%, inset by 1px so it never
-     grows the box, gives it a boundary without giving it a frame.
+     the void merges. A hairline of the ink at 8%, inset by 1px so it never
+     grows the box, gives it a boundary without giving it a frame — and it
+     reads the ink so it flips with the scheme.
   */
   .image-edge {
-    outline: 1px solid rgb(229 229 230 / 8%);
+    outline: 1px solid color-mix(in srgb, var(--color-bone) 8%, transparent);
     outline-offset: -1px;
   }
 }

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -2,19 +2,21 @@
    "Evidence, not claims" — Eva's design system entry point.
 
    The phrase is the product's, printed in its own banner, and the surface is
-   the instrument that prints it: a near-black panel, quiet neutrals, and one
-   ember signal spent only where something is actually happening.
+   the instrument that prints it: a warm near-black panel, quiet neutrals, and
+   one ember signal spent only where something is actually happening.
 
    Two decisions here are measurements rather than taste, and both are argued
    in docs/design.md:
 
-     - The ground is #08090a, not #000000. Pure black reaches 21:1 against
+     - The ground is #0d0b09, not #000000. Pure black reaches 21:1 against
        white, which haloes on OLED and smears text in motion.
      - Prose is a sans and machine output is a mono. A monospaced face slows
        continuous reading, and the documentation is continuous reading.
 
-   The system is dark only. There is no light scheme, no theme toggle, and no
-   scheme cookie; a light surface breaks the system, so none can be expressed.
+   The ladder names ten jobs and carries two schemes over them. Dark is
+   canonical: the bare tokens hold its values. A root carrying `.light`
+   refills every job with its measured light twin; a component never carries
+   a scheme branch of its own.
 
    This file owns two things: the tokens, and the base layer. Everything else
    is one file per concern.
@@ -61,9 +63,10 @@
 
 /*
    The dark variant answers to the `dark` class rather than to the OS setting.
-   The system is dark only, so every app pins `class="dark"` on its root
-   element — the class is what keeps the components' `dark:` utilities live,
-   and the OS preference must not be able to take them away.
+   The scheme is the root's explicit choice — a surface pins `class="dark"`
+   or `class="light"`, or offers the two — and the OS preference must not be
+   able to take the choice away. The class also keeps the shadcn components'
+   `dark:` utilities live on a dark root.
 */
 @custom-variant dark (&:where(.dark, .dark *));
 
@@ -91,23 +94,32 @@
   --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 
   /*
-     The palette, from docs/design.md. Ten neutrals on Linear's ladder — three
-     grounds, three lines, four inks — then the accent and the three states
-     that only ever report a machine outcome. Every measured pairing is in
-     design.md's contrast table.
+     The palette, from docs/design.md. The ladder names ten jobs — three
+     grounds, three lines, four inks — and each scheme fills the same jobs:
+     the values here are the dark scheme, which is canonical, and the .light
+     block below refills every one. The cast is warm on purpose: the panel
+     sits with the ember rather than against it. Every measured pairing, both
+     schemes, is in design.md's contrast tables.
   */
-  --color-void: #08090a;
-  --color-carbon: #0f1011;
-  --color-obsidian: #161718;
-  --color-graphite: #23252a;
-  --color-smoke: #383b3f;
-  --color-ash: #62666d;
-  --color-fog: #8a8f98;
-  --color-mist: #d0d6e0;
-  --color-bone: #e5e5e6;
+  --color-void: #0d0b09;
+  --color-carbon: #14110e;
+  --color-obsidian: #1c1815;
+  --color-graphite: #2b2620;
+  --color-smoke: #453d33;
+  --color-ash: #6e6558;
+  --color-fog: #988d7d;
+  --color-mist: #d9d2c7;
+  --color-bone: #e9e5de;
   --color-paper: #ffffff;
 
+  /*
+     The ink on an ember fill is its own token because it does not follow the
+     ladder: it is near-black on the dark scheme's ember and white on the
+     light scheme's darker one. A fill ink written as `text-void` would flip
+     with the ground and land at 2.65:1 — the one defect design.md names.
+  */
   --color-ember: #ee6018;
+  --color-ember-ink: #0d0b09;
   --color-teal: #02b8cc;
   --color-green: #27a644;
   --color-red: #eb5757;
@@ -165,6 +177,61 @@
   --container-page: 75rem;
   --container-measure: 42.5rem;
   --container-hero: 48rem;
+}
+
+/* ---------------------------------------------------------------------------
+   The two schemes. Dark is canonical: @theme above carries its values, and a
+   surface that says nothing gets it. A root with `.light` refills the same
+   ten jobs — raised is still lighter than the ground, the floor ink is still
+   the floor — and every component built on the ladder flips without a
+   `dark:` branch of its own. The `.dark` block re-asserts the canon so a
+   dark island can sit inside a light page.
+
+   Unlayered on purpose: Tailwind emits the theme variables in a layer, and
+   an unlayered rule is what may override them.
+--------------------------------------------------------------------------- */
+:root {
+  color-scheme: dark;
+}
+
+.dark {
+  color-scheme: dark;
+
+  --color-void: #0d0b09;
+  --color-carbon: #14110e;
+  --color-obsidian: #1c1815;
+  --color-graphite: #2b2620;
+  --color-smoke: #453d33;
+  --color-ash: #6e6558;
+  --color-fog: #988d7d;
+  --color-mist: #d9d2c7;
+  --color-bone: #e9e5de;
+  --color-paper: #ffffff;
+  --color-ember: #ee6018;
+  --color-ember-ink: #0d0b09;
+  --color-teal: #02b8cc;
+  --color-green: #27a644;
+  --color-red: #eb5757;
+}
+
+.light {
+  color-scheme: light;
+
+  --color-void: #f7f4ef;
+  --color-carbon: #fcfaf7;
+  --color-obsidian: #ffffff;
+  --color-graphite: #e8e2d8;
+  --color-smoke: #d6cec1;
+  --color-ash: #8b8172;
+  --color-fog: #6d6353;
+  --color-mist: #514a3f;
+  --color-bone: #272119;
+  --color-paper: #100d0a;
+  --color-ember: #bc4708;
+  --color-ember-ink: #ffffff;
+  --color-teal: #087280;
+  --color-green: #1a7a33;
+  --color-red: #c03434;
 }
 
 :root {

--- a/plugins/themes/src/index.ts
+++ b/plugins/themes/src/index.ts
@@ -15,8 +15,8 @@ export const THEMES: readonly ThemeInfo[] = [
       // docs/design.md's terminal contract: bone, fog, ember — and teal
       // under the contract's `warning` key, because tool output is machine
       // data rather than an alarm.
-      foreground: "#e5e5e6",
-      muted: "#8a8f98",
+      foreground: "#e9e5de",
+      muted: "#988d7d",
       accent: "#ee6018",
       warning: "#02b8cc",
     },


### PR DESCRIPTION
Rebuilds the web door's shell as the evidence-rail layout: an
Attention-grouped Sessions rail, the Session center (Header, Live area,
composer as command center), an evidence pane (Checks, Diff, Cost, Trace),
a status footer, a command palette, and a dark/light scheme toggle over the
warm dual-scheme ladder that landed on main.

The spec and its 14 tickets live in the local (gitignored) tracker at
`plans/evidence-rail/` — spec.md plus issues/01–14. Summary of the graph:

- 01 retire stale pointers (plans-only, no commits) · 02 icons to Phosphor ·
  03 browser E2E harness on a seeded Trace — no blockers
- 04 shell swap (sidebar + resizable + footer region) — blocked by 02, 03
- 05 Attention rail · 06 Header ground truth · 10 composer command row ·
  11 status footer filled · 12 command palette · 13 scheme toggle ·
  14 streaming discipline — blocked by 04
- 07 evidence pane + Checks (blocked by 04, 06) · 08 Diff tab · 09 Cost and
  Trace tabs (blocked by 07)

Each ticket lands green: typecheck, lint, the web suites (props seam,
stylesheet-as-data, store-edge folds), and the Playwright journeys on a
seeded Trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
